### PR TITLE
Add Updates Count to Scrapbook Fields

### DIFF
--- a/src/v0.1/airtable-info.yml
+++ b/src/v0.1/airtable-info.yml
@@ -180,6 +180,7 @@
     - Website
     - GitHub
     - Streaks Toggled Off
+    - Updates Count
     Updates:
     - ID
     - Slack Account


### PR DESCRIPTION
Hey there! 

So I'm working on this workshop, and it'd really really really (x1000) help if this field was available on: https://scrapbook.hackclub.com/api/users/. It'd make the final product so much better!

Before I can add this to the [api/users/index.js](https://github.com/hackclub/summer-scrapbook/blob/main/pages/api/users/index.js) file in Scrapbook I'd need this PR merged.

Hopefully this is alright with all of you!

Thank you!