### PR TITLE
Stop exposing real names for Boba Drops

### DIFF
--- a/src/v0.1/airtable-info.yml
+++ b/src/v0.1/airtable-info.yml
@@ -317,7 +317,6 @@
     - Code URL
     - Playable URL
     - Screenshot
-    - Name
     Event Codes:
     - Status
     - Event Code


### PR DESCRIPTION
Filters out the `Name` property from the Boba Drops table