### PR TITLE
remove exposed club endpoints and changed to club name from venue

### DIFF
--- a/src/v0.1/airtable-info.yml
+++ b/src/v0.1/airtable-info.yml
@@ -48,7 +48,7 @@
   Club Applications:
     baseID: appSUAc40CDu6bDAp
     Clubs Dashboard:
-    - Venue
+    - Club Name
     - Latitude
     - Longitude
     - Status
@@ -82,21 +82,6 @@
     - lng
   Operations:
     baseID: apptEEFG5HTfGQE7h
-    Clubs:
-    - Name
-    - Slack Channel ID
-    - Leader Slack IDs
-    - Leader Names
-    - Address City
-    - Address State
-    - Address Postal Code
-    - Address Country
-    - Meeting sizes
-    - Club URL
-    - Latitude
-    - Longitude
-    - Dummy
-    - Acceptance Time
     Badges:
     - ID
     - Name

--- a/src/v0/allowlist.js
+++ b/src/v0/allowlist.js
@@ -52,18 +52,6 @@ const allowlistInfo = {
     ],
   },
   Operations: {
-    Clubs: [
-      "Name",
-      "Slack Channel ID",
-      "Leader Slack IDs",
-      "Address City",
-      "Address State",
-      "Address Postal Code",
-      "Address Country",
-      "Club URL",
-      "Latitude",
-      "Longitude",
-    ],
     Badges: ["ID", "Name", "Emoji Tag", "Icon", "People Slack IDs"],
   },
   "Command Center Schedule": {


### PR DESCRIPTION
the /Operations/Club endpoint wasn't being used anywhere useful so I just went ahead and removed it from both v0 and v0.1. 

also, changed CLub Applications/Clubs Dashboard's field to Club Name from Venue since we're switching over to Club Names.