### PR TITLE
Remove Club Applications from airtable-info.yml

### DIFF
--- a/src/v0.1/airtable-info.yml
+++ b/src/v0.1/airtable-info.yml
@@ -41,13 +41,6 @@
     - Link
     - Public
     - Name
-  Club Applications:
-    baseID: appSUAc40CDu6bDAp
-    Clubs Dashboard:
-    - Club Name
-    - Latitude
-    - Longitude
-    - Status
   Club Map:
     baseID: appUfrUFraxH3D5Ob
     Clubs:


### PR DESCRIPTION
The old clubs database, no longer needed