### PR TITLE
Lookup auth tokens using airtable instead of v0.1

### DIFF
--- a/src/v0.2/permissions.js
+++ b/src/v0.2/permissions.js
@@ -1,20 +1,30 @@
 import fs from "fs"
 import path from "path"
 import yaml from "js-yaml"
+import Airtable from "airtable"
+
+const AIRBRIDGE_BASE_ID = "appP3uDe6tFt7cA5r"
+const AUTHTOKENS_TABLE = "Authtokens"
+let authtokensTable
+
+function getAuthtokensTable() {
+  if (!authtokensTable) {
+    authtokensTable = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(AIRBRIDGE_BASE_ID)(AUTHTOKENS_TABLE)
+  }
+
+  return authtokensTable
+}
 
 export async function getPermissions(authId) {
   const sanitizedAuthId = String(authId).replace(/'/g, "\\'")
-  const opts = {
-    maxRecords: 1,
-    filterByFormula: `Authtoken='${sanitizedAuthId}'`,
-  }
-
-  const records = await (
-    await fetch(
-      "https://airbridge.hackclub.com/v0.1/Airbridge/Authtokens?select=" +
-        encodeURIComponent(JSON.stringify(opts))
-    )
-  ).json()
+  const records = await getAuthtokensTable()
+    .select({
+      maxRecords: 1,
+      filterByFormula: `Authtoken='${sanitizedAuthId}'`,
+    })
+    .all()
   const record = records[0]
   if (!record) {
     return null

--- a/src/v0.2/permissions.js
+++ b/src/v0.2/permissions.js
@@ -2,6 +2,7 @@ import fs from "fs"
 import path from "path"
 import yaml from "js-yaml"
 import Airtable from "airtable"
+import { sanitizeFormula } from "../shared/formula.js"
 
 const AIRBRIDGE_BASE_ID = "appP3uDe6tFt7cA5r"
 const AUTHTOKENS_TABLE = "Authtokens"
@@ -18,11 +19,15 @@ function getAuthtokensTable() {
 }
 
 export async function getPermissions(authId) {
-  const sanitizedAuthId = String(authId).replace(/'/g, "\\'")
+  const authKey = String(authId)
+  const filterByFormula = sanitizeFormula(
+    `Authtoken=${JSON.stringify(authKey)}`,
+    ["Authtoken"]
+  )
   const records = await getAuthtokensTable()
     .select({
       maxRecords: 1,
-      filterByFormula: `Authtoken='${sanitizedAuthId}'`,
+      filterByFormula,
     })
     .all()
   const record = records[0]


### PR DESCRIPTION
The recent fix in https://github.com/hackclub/airbridge/commit/db04f99c86f92603baed77e81273220611ccf3f2 broke the authentication on v0.2, always making it return `"Error: Invalid authKey provided"` even when the key was correct because the `Authtoken` field is not on v0.1's whitelist.

This PR fixes it by querying airtable directly instead of relying on v0.1 :D

Current (broken) behavior:
```bash
❯ curl -H "authKey: recx3vr3ziWHPc3K0161186195268u9j3l4z9e" \
        "https://api2.hackclub.com/v0.2/Airbridge/Test%20-%20All%20Fields"
$ {"error":"Error: Invalid authKey provided"}
```