### PR TITLE
Add various fields to public Unified

### DIFF
--- a/src/v0.1/airtable-info.yml
+++ b/src/v0.1/airtable-info.yml
@@ -20,6 +20,11 @@
     - Playable URL
     - Approved At
     - YSWS–Name
+    - Country
+    - Description
+    - Repo - Star Count
+    - Archive - Code URL
+    - Archive - Live URL
 
   Assemble:
     baseID: appO6uRegNaw9bfPQ


### PR DESCRIPTION
These fields are already public via ships.hackclub.com (see https://ships.hackclub.com/api/v1/ysws_entries), which frequently experiences outages. It'd be better to just not filter them out in Airbridge to remove the dependency on ships.hackclub.com.